### PR TITLE
Fixed `dispose` does not reset the instance and `isInitialised`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Fixed `dispose` does not reset the instance and `isInitialised`](https://github.com/multiversx/mx-sdk-js-web-wallet-cross-window-provider/pull/77)
+- [Fixed `dispose` does not reset the instance and `isInitialised`](https://github.com/multiversx/mx-sdk-js-web-wallet-cross-window-provider/pull/78)
 
 ## [2.0.4](https://github.com/multiversx/mx-sdk-js-web-wallet-cross-window-provider/pull/76) - 2024-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed `dispose` does not reset the instance and `isInitialised`](https://github.com/multiversx/mx-sdk-js-web-wallet-cross-window-provider/pull/77)
+
 ## [2.0.4](https://github.com/multiversx/mx-sdk-js-web-wallet-cross-window-provider/pull/76) - 2024-12-18
 
 [Fixed duplicate event listeners](https://github.com/multiversx/mx-sdk-js-web-wallet-cross-window-provider/pull/75)

--- a/src/CrossWindowProvider/CrossWindowProvider.ts
+++ b/src/CrossWindowProvider/CrossWindowProvider.ts
@@ -142,6 +142,8 @@ export class CrossWindowProvider {
 
   async dispose(): Promise<boolean> {
     const connectionClosed = await this.windowManager.closeConnection();
+    this.initialized = false;
+    CrossWindowProvider._instance = null;
     return connectionClosed;
   }
 
@@ -154,7 +156,6 @@ export class CrossWindowProvider {
 
     this.ensureConnected();
     const connectionClosed = await this.dispose();
-    this.initialized = false;
     this.disconnect();
 
     return connectionClosed;
@@ -164,6 +165,7 @@ export class CrossWindowProvider {
     if (!this.initialized) {
       throw new ErrProviderNotInitialized();
     }
+
     return this.account?.address ?? '';
   }
 

--- a/src/WindowManager/WindowManager.ts
+++ b/src/WindowManager/WindowManager.ts
@@ -182,6 +182,7 @@ export class WindowManager {
 
     // Reset the session on logout
     this._session = Date.now().toString();
+    this.initialized = false;
 
     return true;
   }


### PR DESCRIPTION
### Issue
`CrossWindowProvider` always remains initialized after dispose and `WindowManager` remains initialized after `closeConnection`


### Fix
Reset the instance and `isInitialized` flag from `CrossWindowProvider` on `dispose` and on `resetConnection` from `WindowManager`